### PR TITLE
Decorator fix

### DIFF
--- a/src/main/kotlin/ru/otus/empty/decorator/Decorator.kt
+++ b/src/main/kotlin/ru/otus/empty/decorator/Decorator.kt
@@ -2,12 +2,4 @@ package ru.otus.empty.decorator
 
 //декоратор
 
- open class Decorator(var drink: Drink = Drink()): Drink() {
-
-    //var drink: Drink = Drink()
-
-    override fun getDeclaration(): String {               //вернуть название
-        return declaration
-    }
-
-}
+ open class Decorator(var drink: Drink = Drink()): Drink()

--- a/src/main/kotlin/ru/otus/empty/decorator/Decorator.kt
+++ b/src/main/kotlin/ru/otus/empty/decorator/Decorator.kt
@@ -2,4 +2,4 @@ package ru.otus.empty.decorator
 
 //декоратор
 
- open class Decorator(var drink: Drink = Drink()): Drink()
+ open class Decorator(mDeclaration: String, var drink: Drink): Drink(mDeclaration)

--- a/src/main/kotlin/ru/otus/empty/decorator/Drink.kt
+++ b/src/main/kotlin/ru/otus/empty/decorator/Drink.kt
@@ -2,9 +2,7 @@ package ru.otus.empty.decorator
 
 //базовый класс
 
-open class Drink {                                 //напиток
-
-    protected var mDeclaration: String = " "                    //описанрие/название
+open class Drink(private val mDeclaration: String) {                                 //напиток
 
     open fun getDeclaration(): String {               //вернуть название
         return mDeclaration

--- a/src/main/kotlin/ru/otus/empty/decorator/Drink.kt
+++ b/src/main/kotlin/ru/otus/empty/decorator/Drink.kt
@@ -4,10 +4,10 @@ package ru.otus.empty.decorator
 
 open class Drink {                                 //напиток
 
-    var declaration: String = " "                    //описанрие/название
+    protected var mDeclaration: String = " "                    //описанрие/название
 
     open fun getDeclaration(): String {               //вернуть название
-        return declaration
+        return mDeclaration
     }
 
     open fun value(): Double{                              //вернуть цену

--- a/src/main/kotlin/ru/otus/empty/decorator/Espresso.kt
+++ b/src/main/kotlin/ru/otus/empty/decorator/Espresso.kt
@@ -1,10 +1,6 @@
 package ru.otus.empty.decorator
 
-class Espresso: Drink() {
-
-    public fun espresso(){
-        mDeclaration = "Espresso"
-    }
+class Espresso: Drink("Espresso") {
 
     override fun value(): Double{
         return 1.75
@@ -12,11 +8,7 @@ class Espresso: Drink() {
 
 }
 
-class Cappuccino: Drink(){
-
-    public fun cappuccino(){
-        mDeclaration = "Cappuccino"
-    }
+class Cappuccino: Drink("Cappuccino"){
 
     override fun value(): Double{
         return 0.85

--- a/src/main/kotlin/ru/otus/empty/decorator/Espresso.kt
+++ b/src/main/kotlin/ru/otus/empty/decorator/Espresso.kt
@@ -3,7 +3,7 @@ package ru.otus.empty.decorator
 class Espresso: Drink() {
 
     public fun espresso(){
-        declaration = "Espresso"
+        mDeclaration = "Espresso"
     }
 
     override fun value(): Double{
@@ -15,7 +15,7 @@ class Espresso: Drink() {
 class Cappuccino: Drink(){
 
     public fun cappuccino(){
-        declaration = "Cappuccino"
+        mDeclaration = "Cappuccino"
     }
 
     override fun value(): Double{

--- a/src/main/kotlin/ru/otus/empty/decorator/MainDecorator.kt
+++ b/src/main/kotlin/ru/otus/empty/decorator/MainDecorator.kt
@@ -10,4 +10,9 @@ fun main() {
     test2 = Milk(test2)
     println(test2.getDeclaration() + " " + test2.value())
 
+    val whiskeyMilk = Whiskey(Milk(Espresso()))
+    val milkWhiskey = Milk(Whiskey(Espresso()))
+
+    println("Coffee, milk then Whiskey: ${whiskeyMilk.getDeclaration()}: ${whiskeyMilk.value()}")
+    println("Coffee, whiskey, then Milk: ${milkWhiskey.getDeclaration()}: ${milkWhiskey.value()}")
 }

--- a/src/main/kotlin/ru/otus/empty/decorator/Milk.kt
+++ b/src/main/kotlin/ru/otus/empty/decorator/Milk.kt
@@ -1,10 +1,6 @@
 package ru.otus.empty.decorator
 
-class Milk(name: Drink) : Decorator() {
-
-    public fun milk(drink: Drink = Drink()){
-        this.drink = drink
-    }
+class Milk(drink: Drink) : Decorator("Milk", drink) {
 
     public override fun getDeclaration(): String{
         return drink.getDeclaration() + ", milk"

--- a/src/main/kotlin/ru/otus/empty/decorator/Whiskey.kt
+++ b/src/main/kotlin/ru/otus/empty/decorator/Whiskey.kt
@@ -1,0 +1,12 @@
+package ru.otus.empty.decorator
+
+class Whiskey(drink: Drink) : Decorator("Whiskey", drink) {
+
+    public override fun getDeclaration(): String{
+        return drink.getDeclaration() + ", whiskey"
+    }
+
+    public override fun value(): Double {
+        return drink.value() + 1.0
+    }
+}


### PR DESCRIPTION
По коммитам отматывай и смотри, что меняется

1. Правка компиляции. Нельзя называть проперти `prop` и геттер `getProp` - на JVM это вызывает конфликт имен
2. Правка декоратора. Ты правильно угадал смысл, но свойства в мейне у тебя не были инициализированы - поэтому имена не прибавлялись
3. Виски, как пример другого декоратора. И смысл композиции в этом паттерне. Через наследование такого не получится